### PR TITLE
bin2textの対象としてシリアライズファイルのみを表示するように変更。

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
+## [0.1.2] - 2022-08-30
+
+- [Changed] リソースファイルに対してbin2textを実行するとエラーとなるので、bin2textの対象はSerializeファイルのみにした。
+- [Changed] WebExtract及びBin2Text実行時に結果をポップアップに表示するようにした。
+
 ## [0.1.1] - 2022-07-12
 
 - 「WebExtract」を押した時に DirectoryNotFoundException が表示される不具合を修正
 - 「Verify」を押した時に NullReferenceException が表示不具合を修正
 
 ## [0.1.0] - 2021-10-15
-
-### Changes
 
 - [0.1.1] Bug Fixed
 - [0.1.0] 1st Release

--- a/Editor/UnityAssetBundleDiffKun.cs
+++ b/Editor/UnityAssetBundleDiffKun.cs
@@ -213,6 +213,7 @@ namespace UTJ.UnityAssetBundleDiffKun
             var exec = new WebExtractExec();
             var path = Path.Combine(workFolderPath, assetBundleFileName);
             var result = exec.Exec($@"""{path}""");
+            EditorUtility.DisplayDialog(result == 0 ? "Success" : "Fail", exec.output, "OK");
             var execFolderPath = dst + "_data";
 
             if (mAssetPaths == null)
@@ -226,8 +227,8 @@ namespace UTJ.UnityAssetBundleDiffKun
 
             var files = Directory.GetFiles(execFolderPath, "BuildPlayer-*", SearchOption.AllDirectories);
             mAssetPaths.AddRange(files);
-
-            files = Directory.GetFiles(execFolderPath, "CAB-*", SearchOption.AllDirectories);
+            // リソースファイルを含めない(拡張子無しのファイルのみを含める)ように修正
+            files = Directory.GetFiles(execFolderPath, "CAB-*.", SearchOption.AllDirectories);
             mAssetPaths.AddRange(files);
             mAssetPaths.Sort();
 
@@ -249,7 +250,8 @@ namespace UTJ.UnityAssetBundleDiffKun
                 var workFolderPath = Path.Combine(Application.temporaryCachePath, mWorkFolderBase);
                 mTextFilePath = Path.Combine(workFolderPath, mAssetNames[mSelectedIndex]) + ".txt";
                 var b2t = new Binary2TextExec();
-                b2t.Exec(mAssetPaths[mSelectedIndex], mTextFilePath, "");
+                var result = b2t.Exec(mAssetPaths[mSelectedIndex], mTextFilePath, "");
+                EditorUtility.DisplayDialog(result == 0 ? "Success" : "Fail", b2t.output, "OK");
                 mText = File.ReadAllText(mTextFilePath);
             }
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ git clone https://github.com/katsumasa/UnityCommandLineTools.git
 
 ## 使い方
 
-`Window > UnityAssetBundleDiffKun`でEditorWindowを起動します。
+`Window > UTJ > UnityAssetBundleDiffKun`でEditorWindowを起動します。
 比較を行いたい二つのAssetBundleをそれぞれ左右のObject Fieldへ指定します。
 
 - [Object Field] 比較を行うAssetBundleを左右のそれぞれの[Object Field]へ設定します。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.utj.unityassetbundlediffkun",
   "displayName": "UnityAssetBundleDiffKun",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "unity": "2019.3",
   "keywords": [
     "unity",


### PR DESCRIPTION
- bin2textの対象をシリアライズファイルのみに変更
- WebExtract及びBin2Text実行後、成功したか否かをポップアップで表示するように変更